### PR TITLE
Close search results whenever link clicked

### DIFF
--- a/main.js
+++ b/main.js
@@ -150,6 +150,7 @@ function intercept_content_link($element) {
         if (match) {
             event.preventDefault();
             load_markdown(link, handle_markdown);
+            $searchResultWrapper.addClass('hide');
         }
     });
 }


### PR DESCRIPTION
If the search results are open, clicking one of them should close the search results; otherwise the page navigates to the link they clicked, but the user might not realise because the results are in the way.